### PR TITLE
Fix dependencies.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,5 +2,5 @@
 (define version 0.2)
 (define collection "ramunk")
 (define categories '(game physics-engine ffi))
-(define deps '(("autoffi" "0.2.0")))
+(define deps '(("autoffi" "0.2")))
 (define compile-omit-paths '("examples" "bin" "chipmunk2d" "chipmunk-release"))


### PR DESCRIPTION
Trailing .0 is not allowed by the version spec.